### PR TITLE
Revert "Update DBeaverCE.munki.recipe"

### DIFF
--- a/DBeaver Corp/DBeaverCE.munki.recipe
+++ b/DBeaver Corp/DBeaverCE.munki.recipe
@@ -42,21 +42,6 @@
 	<key>Process</key>
 	<array>
 		<dict>
-		    <key>Arguments</key>
-		    <dict>
-			<key>input_path</key>
-			<string>%pathname%</string>
-			<key>expected_authority_names</key>
-			<array>
-			    <string>Developer ID Installer: DBeaver Corporation (42B6MDKMW8)</string>
-			    <string>Developer ID Certification Authority</string>
-			    <string>Apple Root CA</string>
-			</array>
-		    </dict>
-		    <key>Processor</key>
-		    <string>CodeSignatureVerifier</string>
-		</dict>
-		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>


### PR DESCRIPTION
Reverts autopkg/blackthroat-recipes#8
```
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: ERROR: Using 'expected_authority_names' to verify code signature is no longer supported. Recipes should use the 'requirement' argument instead.
CodeSignatureVerifier: See https://github.com/autopkg/autopkg/wiki/Using-CodeSignatureVerification for more information.
Traceback (most recent call last):
```