### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Adobe Systems, Inc./AdobeCreativeCloudCleanerTool.pkg.recipe
+++ b/Adobe Systems, Inc./AdobeCreativeCloudCleanerTool.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.Adobe.Installers.AdobeCreativeCloudCleanerTool</string>
 		<key>NAME</key>
 		<string>AdobeCreativeCloudCleanerTool</string>
 	</dict>

--- a/Adobe Systems, Inc./AdobeLogCollectorTool.pkg.recipe
+++ b/Adobe Systems, Inc./AdobeLogCollectorTool.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.AdobeLogCollectorTool</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.Adobe.Installers.AdobeLogCollectorTool</string>
 		<key>NAME</key>
 		<string>AdobeLogCollectorTool</string>
 	</dict>

--- a/COING/ClockifyDesktop.pkg.recipe
+++ b/COING/ClockifyDesktop.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.ClockifyDesktop</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>coing.ClockifyDesktop</string>
 		<key>NAME</key>
 		<string>Clockify Desktop</string>
 	</dict>

--- a/Datap Inc./Dashblock.pkg.recipe
+++ b/Datap Inc./Dashblock.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.Dashblock</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.dashblock.desktop</string>
 		<key>NAME</key>
 		<string>Dashblock</string>
 	</dict>

--- a/Enolsoft Inc./Enolsoft_PDF_Converter_with_OCR.pkg.recipe
+++ b/Enolsoft Inc./Enolsoft_PDF_Converter_with_OCR.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.enolsoft.pdfconverterocr</string>
 		<key>NAME</key>
 		<string>Enolsoft PDF Converter with OCR</string>
 	</dict>

--- a/Framer BV/FramerX.pkg.recipe
+++ b/Framer BV/FramerX.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.FramerX</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.framer.x</string>
 		<key>NAME</key>
 		<string>FramerX</string>
 	</dict>

--- a/KNIME GmbH/KNIME_Analytics_Platform.pkg.recipe
+++ b/KNIME GmbH/KNIME_Analytics_Platform.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.KNIME_Analytics_Platform</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.knime.product</string>
 		<key>NAME</key>
 		<string>KNIME_Analytics_Platform</string>
 	</dict>

--- a/Obvious Matter/Silverback.pkg.recipe
+++ b/Obvious Matter/Silverback.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.Silverback</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>uk.co.clearleft.SilverbackMac</string>
 		<key>NAME</key>
 		<string>Silverback</string>
 	</dict>

--- a/ParseHub/ParseHub.pkg.recipe
+++ b/ParseHub/ParseHub.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.ParseHub</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.mozilla.parsehub</string>
 		<key>NAME</key>
 		<string>ParseHub</string>
 	</dict>

--- a/Pock/Pock.pkg.recipe
+++ b/Pock/Pock.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.Pock</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.pigigaldi.pock</string>
 		<key>NAME</key>
 		<string>Pock</string>
 	</dict>

--- a/RescueTime, Inc/RescueTime.pkg.recipe
+++ b/RescueTime, Inc/RescueTime.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.RescueTime</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.rescuetime.RescueTime</string>
 		<key>NAME</key>
 		<string>RescueTime</string>
 	</dict>

--- a/Rogue Amoeba Software, Inc./Loopback.pkg.recipe
+++ b/Rogue Amoeba Software, Inc./Loopback.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.Loopback</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.rogueamoeba.Loopback</string>
 		<key>NAME</key>
 		<string>Loopback</string>
 	</dict>

--- a/TechSmith Corporation/TechSmithCapture.pkg.recipe
+++ b/TechSmith Corporation/TechSmithCapture.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.TechSmithCapture</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.techsmith.relayrecorder</string>
 		<key>NAME</key>
 		<string>TechSmithCapture</string>
 	</dict>

--- a/WakeOnMac/WakeOnMac.pkg.recipe
+++ b/WakeOnMac/WakeOnMac.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.pkg.WakeOnMac</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.doogul.WakeOnMac</string>
 		<key>NAME</key>
 		<string>WakeOnMac</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Adobe Systems, Inc./AdobeCreativeCloudCleanerTool.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/Adobe\ Systems,\ Inc./AdobeCreativeCloudCleanerTool.pkg.recipe
Processing repos/blackthroat-recipes/Adobe Systems, Inc./AdobeCreativeCloudCleanerTool.pkg.recipe...
URLDownloader
{'Input': {'filename': 'AdobeCreativeCloudCleanerTool.dmg',
           'url': 'https://download.adobe.com/pub/adobe/SupportTools/Cleaner/mac/AdobeCreativeCloudCleanerTool.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/downloads/AdobeCreativeCloudCleanerTool.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/downloads/AdobeCreativeCloudCleanerTool.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/downloads/AdobeCreativeCloudCleanerTool.dmg/Adobe '
                         'Creative Cloud Cleaner Tool.app',
           'requirement': 'identifier '
                          '"com.Adobe.Installers.AdobeCreativeCloudCleanerTool" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'JQ525L2MZD'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/downloads/AdobeCreativeCloudCleanerTool.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.09yQLR/Adobe Creative Cloud Cleaner Tool.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.09yQLR/Adobe Creative Cloud Cleaner Tool.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.09yQLR/Adobe Creative Cloud Cleaner Tool.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/downloads/AdobeCreativeCloudCleanerTool.dmg/Adobe '
                               'Creative Cloud Cleaner '
                               'Tool.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/downloads/AdobeCreativeCloudCleanerTool.dmg
Versioner: Found version 4.3.0.30 in file /private/tmp/dmg.K2shtB/Adobe Creative Cloud Cleaner Tool.app/Contents/Info.plist
{'Output': {'version': '4.3.0.30'}}
AppPkgCreator
{'Input': {'version': '4.3.0.30'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/downloads/AdobeCreativeCloudCleanerTool.dmg
AppPkgCreator: Using path '/private/tmp/dmg.OCTZUV/Adobe Creative Cloud Cleaner Tool.app' matched from globbed '/private/tmp/dmg.OCTZUV/*.app'.
AppPkgCreator: BundleID: com.Adobe.Installers.AdobeCreativeCloudCleanerTool
AppPkgCreator: Copied /private/tmp/dmg.OCTZUV/Adobe Creative Cloud Cleaner Tool.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/payload/Applications/Adobe Creative Cloud Cleaner Tool.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.Adobe.Installers.AdobeCreativeCloudCleanerTool',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/Adobe '
                                                                    'Creative '
                                                                    'Cloud '
                                                                    'Cleaner '
                                                                    'Tool-4.3.0.30.pkg',
                                                        'version': '4.3.0.30'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '4.3.0.30'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/receipts/AdobeCreativeCloudCleanerTool.pkg-receipt-20210213-230108.plist

The following packages were built:
    Identifier                                          Version   Pkg Path                                                                                                                                      
    ----------                                          -------   --------                                                                                                                                      
    com.Adobe.Installers.AdobeCreativeCloudCleanerTool  4.3.0.30  ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeCreativeCloudCleanerTool/Adobe Creative Cloud Cleaner Tool-4.3.0.30.pkg  
```

## ✅ Adobe Systems, Inc./AdobeLogCollectorTool.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/Adobe\ Systems,\ Inc./AdobeLogCollectorTool.pkg.recipe
Processing repos/blackthroat-recipes/Adobe Systems, Inc./AdobeLogCollectorTool.pkg.recipe...
URLDownloader
{'Input': {'filename': 'AdobeLogCollectorTool.dmg',
           'url': 'https://download.adobe.com/pub/adobe/SupportTools/LogCollector/mac/LogCollectorTool.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/downloads/AdobeLogCollectorTool.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/downloads/AdobeLogCollectorTool.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/downloads/AdobeLogCollectorTool.dmg/Log '
                         'Collector tool.app',
           'requirement': 'identifier '
                          '"com.Adobe.Installers.AdobeLogCollectorTool" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'JQ525L2MZD'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/downloads/AdobeLogCollectorTool.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.LDzTTD/Log Collector tool.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.LDzTTD/Log Collector tool.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.LDzTTD/Log Collector tool.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/downloads/AdobeLogCollectorTool.dmg/Log '
                               'Collector tool.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/downloads/AdobeLogCollectorTool.dmg
Versioner: Found version 4.0.0.15 in file /private/tmp/dmg.UITWNp/Log Collector tool.app/Contents/Info.plist
{'Output': {'version': '4.0.0.15'}}
AppPkgCreator
{'Input': {'version': '4.0.0.15'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/downloads/AdobeLogCollectorTool.dmg
AppPkgCreator: Using path '/private/tmp/dmg.bS59Ez/Log Collector tool.app' matched from globbed '/private/tmp/dmg.bS59Ez/*.app'.
AppPkgCreator: BundleID: com.Adobe.Installers.AdobeLogCollectorTool
AppPkgCreator: Copied /private/tmp/dmg.bS59Ez/Log Collector tool.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/payload/Applications/Log Collector tool.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.Adobe.Installers.AdobeLogCollectorTool',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/Log '
                                                                    'Collector '
                                                                    'tool-4.0.0.15.pkg',
                                                        'version': '4.0.0.15'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '4.0.0.15'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/receipts/AdobeLogCollectorTool.pkg-receipt-20210213-230116.plist

The following packages were built:
    Identifier                                  Version   Pkg Path                                                                                                               
    ----------                                  -------   --------                                                                                                               
    com.Adobe.Installers.AdobeLogCollectorTool  4.0.0.15  ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.AdobeLogCollectorTool/Log Collector tool-4.0.0.15.pkg  
```

## ✅ COING/ClockifyDesktop.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/COING/ClockifyDesktop.pkg.recipe
Processing repos/blackthroat-recipes/COING/ClockifyDesktop.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 202
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.6.6
SparkleUpdateInfoProvider: Found URL https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop.zip
{'Output': {'url': 'https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop.zip',
            'version': '2.6.6'}}
URLDownloader
{'Input': {'filename': 'Clockify Desktop-2.6.6.zip',
           'url': 'https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/downloads/Clockify Desktop-2.6.6.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/downloads/Clockify '
                        'Desktop-2.6.6.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/downloads/Clockify '
                           'Desktop-2.6.6.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/Clockify '
                               'Desktop',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Clockify Desktop-2.6.6.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/downloads/Clockify Desktop-2.6.6.zip to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/Clockify Desktop
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/Clockify '
                         'Desktop/Clockify Desktop.app',
           'requirement': 'anchor apple generic and identifier '
                          '"coing.ClockifyDesktop" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "3PWTDBRQZQ")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/Clockify Desktop/Clockify Desktop.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/Clockify Desktop/Clockify Desktop.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/Clockify Desktop/Clockify Desktop.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/Clockify '
                       'Desktop/Clockify Desktop.app',
           'version': '2.6.6'}}
AppPkgCreator: BundleID: coing.ClockifyDesktop
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/Clockify Desktop/Clockify Desktop.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/payload/Applications/Clockify Desktop.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'coing.ClockifyDesktop',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/Clockify '
                                                                    'Desktop-2.6.6.pkg',
                                                        'version': '2.6.6'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.6.6'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/receipts/ClockifyDesktop.pkg-receipt-20210213-230128.plist

The following packages were built:
    Identifier             Version  Pkg Path                                                                                                    
    ----------             -------  --------                                                                                                    
    coing.ClockifyDesktop  2.6.6    ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ClockifyDesktop/Clockify Desktop-2.6.6.pkg  
```

## ✅ Datap Inc./Dashblock.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/Datap\ Inc./Dashblock.pkg.recipe
Processing repos/blackthroat-recipes/Datap Inc./Dashblock.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\.zip$',
           'github_repo': 'dashblock/desktop-releases'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex '.*\.zip$' among asset(s): Dashblock-0.0.15-mac.zip, Dashblock.Setup.0.0.15.exe, Dashblock.Setup.0.0.15.zip, latest-mac.yml, latest.yml
GitHubReleasesInfoProvider: Selected asset 'Dashblock-0.0.15-mac.zip' from release '0.0.15'
{'Output': {'url': 'https://github.com/dashblock/desktop-releases/releases/download/v0.0.15/Dashblock-0.0.15-mac.zip',
            'version': '0.0.15'}}
URLDownloader
{'Input': {'filename': 'Dashblock-0.0.15-mac.zip',
           'url': 'https://github.com/dashblock/desktop-releases/releases/download/v0.0.15/Dashblock-0.0.15-mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/downloads/Dashblock-0.0.15-mac.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/downloads/Dashblock-0.0.15-mac.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/downloads/Dashblock-0.0.15-mac.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Dashblock-0.0.15-mac.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/downloads/Dashblock-0.0.15-mac.zip to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock/Dashblock.app',
           'requirement': 'identifier "com.dashblock.desktop" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'TG7H9D7DP4'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock/Dashblock.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock/Dashblock.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock/Dashblock.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock/Dashblock.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 0.0.15 in file ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock/Dashblock.app/Contents/Info.plist
{'Output': {'version': '0.0.15'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock/Dashblock.app',
           'version': '0.0.15'}}
AppPkgCreator: BundleID: com.dashblock.desktop
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock/Dashblock.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/payload/Applications/Dashblock.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.dashblock.desktop',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock-0.0.15.pkg',
                                                        'version': '0.0.15'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '0.0.15'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/receipts/Dashblock.pkg-receipt-20210213-230152.plist

The following packages were built:
    Identifier             Version  Pkg Path                                                                                        
    ----------             -------  --------                                                                                        
    com.dashblock.desktop  0.0.15   ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Dashblock/Dashblock-0.0.15.pkg  
```

## ✅ Enolsoft Inc./Enolsoft_PDF_Converter_with_OCR.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/Enolsoft\ Inc./Enolsoft_PDF_Converter_with_OCR.pkg.recipe
Processing repos/blackthroat-recipes/Enolsoft Inc./Enolsoft_PDF_Converter_with_OCR.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Enolsoft PDF Converter with OCR.dmg',
           'url': 'https://download.enolsoft.com/enolsoft-pdf-converter-with-ocr.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/downloads/Enolsoft PDF Converter with OCR.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/downloads/Enolsoft '
                        'PDF Converter with OCR.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/downloads/Enolsoft '
                         'PDF Converter with OCR.dmg/Enolsoft PDF Converter '
                         'with OCR.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.enolsoft.pdfconverterocr" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5HGV8EX6BQ")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/downloads/Enolsoft PDF Converter with OCR.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.PgY9kE/Enolsoft PDF Converter with OCR.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.PgY9kE/Enolsoft PDF Converter with OCR.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.PgY9kE/Enolsoft PDF Converter with OCR.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/downloads/Enolsoft '
                               'PDF Converter with OCR.dmg/Enolsoft PDF '
                               'Converter with OCR.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/downloads/Enolsoft PDF Converter with OCR.dmg
Versioner: Found version 6.8.0 in file /private/tmp/dmg.dofPeu/Enolsoft PDF Converter with OCR.app/Contents/Info.plist
{'Output': {'version': '6.8.0'}}
AppPkgCreator
{'Input': {'version': '6.8.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/downloads/Enolsoft PDF Converter with OCR.dmg
AppPkgCreator: Using path '/private/tmp/dmg.Tylq7k/Enolsoft PDF Converter with OCR.app' matched from globbed '/private/tmp/dmg.Tylq7k/*.app'.
AppPkgCreator: BundleID: com.enolsoft.pdfconverterocr
AppPkgCreator: Copied /private/tmp/dmg.Tylq7k/Enolsoft PDF Converter with OCR.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/payload/Applications/Enolsoft PDF Converter with OCR.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.enolsoft.pdfconverterocr',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/Enolsoft '
                                                                    'PDF '
                                                                    'Converter '
                                                                    'with '
                                                                    'OCR-6.8.0.pkg',
                                                        'version': '6.8.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '6.8.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/receipts/Enolsoft_PDF_Converter_with_OCR.pkg-receipt-20210213-230346.plist

The following packages were built:
    Identifier                    Version  Pkg Path                                                                                                                                   
    ----------                    -------  --------                                                                                                                                   
    com.enolsoft.pdfconverterocr  6.8.0    ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Enolsoft_PDF_Converter_with_OCR/Enolsoft PDF Converter with OCR-6.8.0.pkg  
```

## ✅ Framer BV/FramerX.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/Framer\ BV/FramerX.pkg.recipe
Processing repos/blackthroat-recipes/Framer BV/FramerX.pkg.recipe...
URLDownloader
{'Input': {'filename': 'FramerX.zip',
           'url': 'https://dl.devmate.com/com.framer.x/FramerX.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/downloads/FramerX.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/downloads/FramerX.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/downloads/FramerX.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/FramerX',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename FramerX.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/downloads/FramerX.zip to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/FramerX
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/FramerX/Framer '
                         'X.app',
           'requirement': 'identifier "com.framer.x" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = JZ2M63CZ28'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/FramerX/Framer X.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/FramerX/Framer X.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/FramerX/Framer X.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/FramerX/Framer '
                               'X.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: Found version 36830 in file ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/FramerX/Framer X.app/Contents/Info.plist
{'Output': {'version': '36830'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/FramerX/Framer '
                       'X.app',
           'version': '36830'}}
AppPkgCreator: BundleID: com.framer.x
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/FramerX/Framer X.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/payload/Applications/Framer X.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.framer.x',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/Framer '
                                                                    'X-36830.pkg',
                                                        'version': '36830'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '36830'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/receipts/FramerX.pkg-receipt-20210213-230427.plist

The following packages were built:
    Identifier    Version  Pkg Path                                                                                    
    ----------    -------  --------                                                                                    
    com.framer.x  36830    ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.FramerX/Framer X-36830.pkg  
```

## ✅ KNIME GmbH/KNIME_Analytics_Platform.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/KNIME\ GmbH/KNIME_Analytics_Platform.pkg.recipe
Processing repos/blackthroat-recipes/KNIME GmbH/KNIME_Analytics_Platform.pkg.recipe...
URLDownloader
{'Input': {'filename': 'KNIME_Analytics_Platform.dmg',
           'url': 'https://download.knime.org/analytics-platform/macosx/knime-latest-app.macosx.cocoa.x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg/KNIME*.app',
           'requirement': 'identifier "org.knime.desktop.product" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'V7WZJX2HS9'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.2b3Uxu/KNIME 4.3.1.app' matched from globbed '/private/tmp/dmg.2b3Uxu/KNIME*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.2b3Uxu/KNIME 4.3.1.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.2b3Uxu/KNIME 4.3.1.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.2b3Uxu/KNIME 4.3.1.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg
AppDmgVersioner: BundleID: org.knime.product
AppDmgVersioner: Version: 4.3.1
{'Output': {'app_name': 'KNIME 4.3.1.app',
            'bundleid': 'org.knime.product',
            'version': '4.3.1'}}
AppPkgCreator
{'Input': {'bundleid': 'org.knime.product', 'version': '4.3.1'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg
AppPkgCreator: Using path '/private/tmp/dmg.nqoXQe/KNIME 4.3.1.app' matched from globbed '/private/tmp/dmg.nqoXQe/*.app'.
AppPkgCreator: Copied /private/tmp/dmg.nqoXQe/KNIME 4.3.1.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/payload/Applications/KNIME 4.3.1.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.knime.product',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/KNIME '
                                                                    '4.3.1-4.3.1.pkg',
                                                        'version': '4.3.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '4.3.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/receipts/KNIME_Analytics_Platform.pkg-receipt-20210213-231106.plist

The following packages were built:
    Identifier         Version  Pkg Path                                                                                                        
    ----------         -------  --------                                                                                                        
    org.knime.product  4.3.1    ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.KNIME_Analytics_Platform/KNIME 4.3.1-4.3.1.pkg  
```

## ✅ Obvious Matter/Silverback.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/Obvious\ Matter/Silverback.pkg.recipe
Processing repos/blackthroat-recipes/Obvious Matter/Silverback.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Silverback.zip',
           'url': 'https://dl.devmate.com/uk.co.clearleft.SilverbackMac/Silverback.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/downloads/Silverback.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/downloads/Silverback.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/downloads/Silverback.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Silverback.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/downloads/Silverback.zip to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback/Silverback.app',
           'requirement': 'anchor apple generic and identifier '
                          '"uk.co.clearleft.SilverbackMac" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = LU8J66X765)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback/Silverback.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback/Silverback.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback/Silverback.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback/Silverback.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 3.1.8 in file ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback/Silverback.app/Contents/Info.plist
{'Output': {'version': '3.1.8'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback/Silverback.app',
           'version': '3.1.8'}}
AppPkgCreator: BundleID: uk.co.clearleft.SilverbackMac
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback/Silverback.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/payload/Applications/Silverback.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'uk.co.clearleft.SilverbackMac',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback-3.1.8.pkg',
                                                        'version': '3.1.8'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.1.8'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/receipts/Silverback.pkg-receipt-20210213-230903.plist

The following packages were built:
    Identifier                     Version  Pkg Path                                                                                         
    ----------                     -------  --------                                                                                         
    uk.co.clearleft.SilverbackMac  3.1.8    ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Silverback/Silverback-3.1.8.pkg  
```

## ✅ ParseHub/ParseHub.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/ParseHub/ParseHub.pkg.recipe
Processing repos/blackthroat-recipes/ParseHub/ParseHub.pkg.recipe...
URLDownloader
{'Input': {'filename': 'ParseHub.dmg',
           'url': 'https://www.parsehub.com/static/client/parsehub.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ParseHub/downloads/ParseHub.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ParseHub/downloads/ParseHub.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ParseHub/downloads/ParseHub.dmg
AppPkgCreator: Using path '/private/tmp/dmg.hniGdI/ParseHub.app' matched from globbed '/private/tmp/dmg.hniGdI/*.app'.
AppPkgCreator: Version: 54.0.1
AppPkgCreator: BundleID: org.mozilla.parsehub
AppPkgCreator: Copied /private/tmp/dmg.hniGdI/ParseHub.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ParseHub/payload/Applications/ParseHub.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.mozilla.parsehub',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ParseHub/ParseHub-54.0.1.pkg',
                                                        'version': '54.0.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '54.0.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ParseHub/receipts/ParseHub.pkg-receipt-20210213-230925.plist

The following packages were built:
    Identifier            Version  Pkg Path                                                                                      
    ----------            -------  --------                                                                                      
    org.mozilla.parsehub  54.0.1   ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.ParseHub/ParseHub-54.0.1.pkg  
```

## ❌ Pock/Pock.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/Pock/Pock.pkg.recipe
Processing repos/blackthroat-recipes/Pock/Pock.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Pock.zip',
           'url': 'https://pock.dev/download.php?file=pock_0_7_2.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Pock/downloads/Pock.zip
{'Output': {'download_changed': True,
            'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Pock/downloads/Pock.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Pock/downloads/Pock.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Pock/downloads/Pock.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Pock/Pock',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Pock.zip
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Pock/receipts/Pock.pkg-receipt-20210213-230927.plist

The following recipes failed:
    repos/blackthroat-recipes/Pock/Pock.pkg.recipe
        Error in com.github.blackthroat.pkg.Pock: Processor: Unarchiver: Error: Unarchiving ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Pock/downloads/Pock.zip with ditto failed: ditto: Couldn't read PKZip signature

The following new items were downloaded:
    Download Path                                                                            
    -------------                                                                            
    ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Pock/downloads/Pock.zip  
```

## ✅ RescueTime, Inc/RescueTime.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/RescueTime,\ Inc/RescueTime.pkg.recipe
Processing repos/blackthroat-recipes/RescueTime, Inc/RescueTime.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.rescuetime.com/installers/appcast'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.16.6.1
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.16.6.1
SparkleUpdateInfoProvider: Found URL https://www.rescuetime.com/installers/RescueTimeInstaller.app.zip
{'Output': {'url': 'https://www.rescuetime.com/installers/RescueTimeInstaller.app.zip',
            'version': '2.16.6.1'}}
URLDownloader
{'Input': {'filename': 'RescueTime-2.16.6.1.zip',
           'url': 'https://www.rescuetime.com/installers/RescueTimeInstaller.app.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/downloads/RescueTime-2.16.6.1.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/downloads/RescueTime-2.16.6.1.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/downloads/RescueTime-2.16.6.1.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/RescueTime',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename RescueTime-2.16.6.1.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/downloads/RescueTime-2.16.6.1.zip to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/RescueTime
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/RescueTime/RescueTime.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.rescuetime.RescueTime" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = FSY4RB8H39)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/RescueTime/RescueTime.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/RescueTime/RescueTime.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/RescueTime/RescueTime.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/RescueTime/RescueTime.app',
           'version': '2.16.6.1'}}
AppPkgCreator: BundleID: com.rescuetime.RescueTime
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/RescueTime/RescueTime.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/payload/Applications/RescueTime.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.rescuetime.RescueTime',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/RescueTime-2.16.6.1.pkg',
                                                        'version': '2.16.6.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.16.6.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/receipts/RescueTime.pkg-receipt-20210213-230933.plist

The following packages were built:
    Identifier                 Version   Pkg Path                                                                                            
    ----------                 -------   --------                                                                                            
    com.rescuetime.RescueTime  2.16.6.1  ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.RescueTime/RescueTime-2.16.6.1.pkg  
```

## ✅ Rogue Amoeba Software, Inc./Loopback.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/Rogue\ Amoeba\ Software,\ Inc./Loopback.pkg.recipe
Processing repos/blackthroat-recipes/Rogue Amoeba Software, Inc./Loopback.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Loopback.zip',
           'url': 'https://rogueamoeba.com/loopback/download/Loopback.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/downloads/Loopback.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/downloads/Loopback.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/downloads/Loopback.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Loopback.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/downloads/Loopback.zip to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback/Loopback.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.rogueamoeba.Loopback" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "7266XEXAPM")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback/Loopback.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback/Loopback.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback/Loopback.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback/Loopback.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 2.2.2 in file ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback/Loopback.app/Contents/Info.plist
{'Output': {'version': '2.2.2'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback/Loopback.app',
           'version': '2.2.2'}}
AppPkgCreator: BundleID: com.rogueamoeba.Loopback
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback/Loopback.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/payload/Applications/Loopback.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.rogueamoeba.Loopback',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback-2.2.2.pkg',
                                                        'version': '2.2.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.2.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/receipts/Loopback.pkg-receipt-20210213-230938.plist

The following packages were built:
    Identifier                Version  Pkg Path                                                                                     
    ----------                -------  --------                                                                                     
    com.rogueamoeba.Loopback  2.2.2    ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.Loopback/Loopback-2.2.2.pkg  
```

## ✅ TechSmith Corporation/TechSmithCapture.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/TechSmith\ Corporation/TechSmithCapture.pkg.recipe
Processing repos/blackthroat-recipes/TechSmith Corporation/TechSmithCapture.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.techsmith.com/redirect.asp?target=sparkleappcast&product=techsmithcapturemac&ver=1.1.0&lang=enu&os=mac'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 198
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.3.31
SparkleUpdateInfoProvider: Found URL https://assets.techsmith.com/techsmithcapture/mac/TechSmithCapture.dmg
{'Output': {'url': 'https://assets.techsmith.com/techsmithcapture/mac/TechSmithCapture.dmg',
            'version': '1.3.31'}}
URLDownloader
{'Input': {'filename': 'TechSmithCapture-1.3.31.dmg',
           'url': 'https://assets.techsmith.com/techsmithcapture/mac/TechSmithCapture.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.TechSmithCapture/downloads/TechSmithCapture-1.3.31.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.TechSmithCapture/downloads/TechSmithCapture-1.3.31.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.TechSmithCapture/downloads/TechSmithCapture-1.3.31.dmg/TechSmith '
                         'Capture.app',
           'requirement': 'identifier "com.techsmith.relayrecorder" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"7TQL462TU8"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.TechSmithCapture/downloads/TechSmithCapture-1.3.31.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.AUJTlG/TechSmith Capture.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.AUJTlG/TechSmith Capture.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.AUJTlG/TechSmith Capture.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '1.3.31'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.TechSmithCapture/downloads/TechSmithCapture-1.3.31.dmg
AppPkgCreator: Using path '/private/tmp/dmg.2xp26F/TechSmith Capture.app' matched from globbed '/private/tmp/dmg.2xp26F/*.app'.
AppPkgCreator: BundleID: com.techsmith.relayrecorder
AppPkgCreator: Copied /private/tmp/dmg.2xp26F/TechSmith Capture.app to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.TechSmithCapture/payload/Applications/TechSmith Capture.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.techsmith.relayrecorder',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.TechSmithCapture/TechSmith '
                                                                    'Capture-1.3.31.pkg',
                                                        'version': '1.3.31'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.3.31'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.TechSmithCapture/receipts/TechSmithCapture.pkg-receipt-20210213-230951.plist

The following packages were built:
    Identifier                   Version  Pkg Path                                                                                                       
    ----------                   -------  --------                                                                                                       
    com.techsmith.relayrecorder  1.3.31   ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.TechSmithCapture/TechSmith Capture-1.3.31.pkg  
```

## ❌ WakeOnMac/WakeOnMac.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/blackthroat-recipes/WakeOnMac/WakeOnMac.pkg.recipe
Processing repos/blackthroat-recipes/WakeOnMac/WakeOnMac.pkg.recipe...
URLDownloader
{'Input': {'filename': 'WakeOnMac.dmg',
           'url': 'https://software.doogul.com/wom/wom.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.WakeOnMac/downloads/WakeOnMac.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.WakeOnMac/downloads/WakeOnMac.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.WakeOnMac/downloads/WakeOnMac.dmg
AppPkgCreator: Using path '/private/tmp/dmg.aCUUOe/WakeOnMac.app' matched from globbed '/private/tmp/dmg.aCUUOe/*.app'.
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.pkg.WakeOnMac/receipts/WakeOnMac.pkg-receipt-20210213-230954.plist

The following recipes failed:
    repos/blackthroat-recipes/WakeOnMac/WakeOnMac.pkg.recipe
        Error in com.github.blackthroat.pkg.WakeOnMac: Processor: AppPkgCreator: Error: 'CFBundleShortVersionString'

Nothing downloaded, packaged or imported.
```
