### PR TITLE
Updated PlantronicsHub recipes

### DIFF
--- a/Plantronics, Inc./PlantronicsHub.download.recipe
+++ b/Plantronics, Inc./PlantronicsHub.download.recipe
@@ -2,88 +2,49 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Comment</key>
-	<string>Created with Recipe Robot v2.1.0 (https://github.com/homebysix/recipe-robot)</string>
-	<key>Description</key>
-	<string>Downloads the latest version of Plantronics Hub.</string>
-	<key>Identifier</key>
-	<string>com.github.blackthroat.download.PlantronicsHub</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>PlantronicsHub</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>1.0.0</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>https://www.poly.com/content/dam/www/software/PlantronicsHubInstaller.dmg</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Installer: Plantronics, Inc. (SKWK2Q7JJV)</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
-				<key>input_path</key>
-				<string>%pathname%/Plantronics Software.pkg</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack</string>
-				<key>flat_pkg_path</key>
-				<string>%pathname%/Plantronics Software.pkg</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload</string>
-				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/inner.pkg/Payload</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>PkgPayloadUnpacker</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/payload/Contents/Frameworks/Plantronics Hub Helper.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-		</dict>
-	</array>
+    <key>Description</key>
+    <string>Downloads the latest version of Plantronics Hub.</string>
+    <key>Identifier</key>
+    <string>com.github.blackthroat.download.PlantronicsHub</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>PlantronicsHub</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>Process</key>
+    <array>
+        <dict>
+           <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+                <key>url</key>
+                <string>https://www.poly.com/content/dam/www/software/PlantronicsHubInstaller.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Plantronics, Inc. (SKWK2Q7JJV)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+                <key>input_path</key>
+                <string>%pathname%/Plantronics Software.pkg</string>
+            </dict>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/Plantronics, Inc./PlantronicsHub.munki.recipe
+++ b/Plantronics, Inc./PlantronicsHub.munki.recipe
@@ -65,17 +65,6 @@
             </dict>
         </dict>
         <dict>
-          <key>Processor</key>
-          <string>Versioner</string>
-          <key>Arguments</key>
-          <dict>
-              <key>input_plist_path</key>
-              <string>%destination_path%/Contents/Info.plist</string>
-              <key>plist_version_key</key>
-              <string>CFBundleShortVersionString</string>
-          </dict>
-        </dict>
-        <dict>
             <key>Processor</key>
             <string>MunkiInstallsItemsCreator</string>
             <key>Arguments</key>
@@ -91,14 +80,6 @@
        <dict>
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
-            <key>Arguments</key>
-            <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-                    <key>version</key>
-                    <string>%version%</string>
-                </dict>
-            </dict>
         </dict>
         <dict>
             <key>Processor</key>
@@ -109,6 +90,29 @@
                 <string>%pathname%/Plantronics Software.pkg</string>
                 <key>pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+          <key>Processor</key>
+          <string>Versioner</string>
+          <key>Arguments</key>
+          <dict>
+              <key>input_plist_path</key>
+              <string>%destination_path%/Contents/Info.plist</string>
+              <key>plist_version_key</key>
+              <string>CFBundleShortVersionString</string>
+          </dict>
+        </dict>
+       <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
             </dict>
         </dict>
         <dict>

--- a/Plantronics, Inc./PlantronicsHub.munki.recipe
+++ b/Plantronics, Inc./PlantronicsHub.munki.recipe
@@ -2,57 +2,138 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Comment</key>
-	<string>Created with Recipe Robot v2.1.0 (https://github.com/homebysix/recipe-robot)</string>
-	<key>Description</key>
-	<string>Downloads the latest version of Plantronics Hub and imports it into Munki.</string>
-	<key>Identifier</key>
-	<string>com.github.blackthroat.munki.PlantronicsHub</string>
-	<key>Input</key>
-	<dict>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/%NAME%</string>
-		<key>NAME</key>
-		<string>PlantronicsHub</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>blocking_applications</key>
-			<array>
-				<string>Plantronics Hub.app</string>
-			</array>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>description</key>
-			<string>Allows end-users to customize their settings and get visible status of their Plantronics audio device on their desktop.</string>
-			<key>developer</key>
-			<string>Plantronics, Inc.</string>
-			<key>display_name</key>
-			<string>Plantronics Hub</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-		</dict>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>1.0.0</string>
-	<key>ParentRecipe</key>
-	<string>com.github.blackthroat.download.PlantronicsHub</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%pathname%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-		</dict>
-	</array>
+    <key>Identifier</key>
+    <string>com.github.blackthroat.munki.PlantronicsHub</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/%NAME%</string>
+        <key>NAME</key>
+        <string>PlantronicsHub</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>blocking_applications</key>
+            <array>
+                <string>Plantronics Hub.app</string>
+            </array>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Allows end-users to customize their settings and get visible status of their Plantronics audio device on their desktop.</string>
+            <key>developer</key>
+            <string>Plantronics, Inc.</string>
+            <key>display_name</key>
+            <string>Plantronics Hub</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.blackthroat.download.PlantronicsHub</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%/Plantronics Software.pkg</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Plantronics Hub.app</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/inner.pkg/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+          <key>Processor</key>
+          <string>Versioner</string>
+          <key>Arguments</key>
+          <dict>
+              <key>input_plist_path</key>
+              <string>%destination_path%/Contents/Info.plist</string>
+              <key>plist_version_key</key>
+              <string>CFBundleShortVersionString</string>
+          </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Plantronics Hub.app</string>
+                </array>
+            </dict>
+        </dict>
+       <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgCopier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_pkg</key>
+                <string>%pathname%/Plantronics Software.pkg</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pkg_path%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </array>
+            </dict>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/Plantronics, Inc./PlantronicsHub.pkg.recipe
+++ b/Plantronics, Inc./PlantronicsHub.pkg.recipe
@@ -2,27 +2,81 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Comment</key>
-	<string>Created with Recipe Robot v2.1.0 (https://github.com/homebysix/recipe-robot)</string>
-	<key>Description</key>
-	<string>Downloads the latest version of Plantronics Hub and creates a package.</string>
-	<key>Identifier</key>
-	<string>com.github.blackthroat.pkg.PlantronicsHub</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>PlantronicsHub</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>1.0.0</string>
-	<key>ParentRecipe</key>
-	<string>com.github.blackthroat.download.PlantronicsHub</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Processor</key>
-			<string>AppPkgCreator</string>
-		</dict>
-	</array>
+    <key>Description</key>
+    <string>Downloads the latest version of Plantronics Hub and creates a package.</string>
+    <key>Identifier</key>
+    <string>com.github.blackthroat.pkg.PlantronicsHub</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>PlantronicsHub</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.blackthroat.download.PlantronicsHub</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%/Plantronics Software.pkg</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/Plantronics Hub.app</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/inner.pkg/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+          <key>Processor</key>
+          <string>Versioner</string>
+          <key>Arguments</key>
+          <dict>
+              <key>input_plist_path</key>
+              <string>%destination_path%/Contents/Info.plist</string>
+              <key>plist_version_key</key>
+              <string>CFBundleShortVersionString</string>
+          </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgCopier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source_pkg</key>
+                <string>%pathname%/Plantronics Software.pkg</string>
+                <key>pkg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                    <string>%RECIPE_CACHE_DIR%/unpack</string>
+                </array>
+            </dict>
+        </dict>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Recipes now look for the version within the main app, as previously was reporting version 0.0.

This also creates an installs array for Munki looking at the app on disk.

.install recipe has been kept, but I can't see how that ever worked.

```
autopkg run -vv ./PlantronicsHub.munki.recipe
Processing ./PlantronicsHub.munki.recipe...
WARNING: ./PlantronicsHub.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'PlantronicsHub.dmg',
           'url': 'https://www.poly.com/content/dam/www/software/PlantronicsHubInstaller.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/downloads/PlantronicsHub.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/downloads/PlantronicsHub.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Plantronics, '
                                        'Inc. (SKWK2Q7JJV)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/downloads/PlantronicsHub.dmg/Plantronics '
                         'Software.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/downloads/PlantronicsHub.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Plantronics Software.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-01-27 19:03:23 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Plantronics, Inc. (SKWK2Q7JJV)
CodeSignatureVerifier:        Expires: 2023-11-28 22:59:41 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B3 EF 7B 6D 2F C2 D8 8A 7C 53 11 6F EB B8 81 BC 69 15 D9 F9 6F 38 
CodeSignatureVerifier:            91 92 FC EC 3F F1 60 DC 1C 50
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/downloads/PlantronicsHub.dmg/Plantronics '
                            'Software.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/downloads/PlantronicsHub.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.IQvc1C/Plantronics Software.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/Applications/Plantronics '
                               'Hub.app',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/unpack/inner.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/unpack/inner.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/Applications/Plantronics Hub.app
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/Applications/Plantronics '
                               'Hub.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 3.21.53118.27704 in file /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/Applications/Plantronics Hub.app/Contents/Info.plist
{'Output': {'version': '3.21.53118.27704'}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub',
           'installs_item_paths': ['/Applications/Plantronics Hub.app']}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Plantronics Hub.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'Plantronics-Inc..Plantronics-Hub',
                                                 'CFBundleName': 'Plantronics '
                                                                 'Hub',
                                                 'CFBundleShortVersionString': '3.21.53118.27704',
                                                 'CFBundleVersion': '3.21.53118.27704',
                                                 'minosversion': '10.10',
                                                 'path': '/Applications/Plantronics '
                                                         'Hub.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '3.21.53118.27704'},
           'pkginfo': {'blocking_applications': ['Plantronics Hub.app'],
                       'catalogs': ['testing'],
                       'description': 'Allows end-users to customize their '
                                      'settings and get visible status of '
                                      'their Plantronics audio device on their '
                                      'desktop.',
                       'developer': 'Plantronics, Inc.',
                       'display_name': 'Plantronics Hub',
                       'name': 'PlantronicsHub',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '3.21.53118.27704'} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Plantronics Hub.app'],
                        'catalogs': ['testing'],
                        'description': 'Allows end-users to customize their '
                                       'settings and get visible status of '
                                       'their Plantronics audio device on '
                                       'their desktop.',
                        'developer': 'Plantronics, Inc.',
                        'display_name': 'Plantronics Hub',
                        'name': 'PlantronicsHub',
                        'unattended_install': True,
                        'version': '3.21.53118.27704'}}}
PkgCopier
{'Input': {'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/PlantronicsHub.pkg',
           'source_pkg': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/downloads/PlantronicsHub.dmg/Plantronics '
                         'Software.pkg'}}
PkgCopier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/downloads/PlantronicsHub.dmg
PkgCopier: Copied /private/tmp/dmg.pEE6Ju/Plantronics Software.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/PlantronicsHub.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/PlantronicsHub.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/PlantronicsHub.pkg'}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/PlantronicsHub.pkg',
           'pkginfo': {'blocking_applications': ['Plantronics Hub.app'],
                       'catalogs': ['testing'],
                       'description': 'Allows end-users to customize their '
                                      'settings and get visible status of '
                                      'their Plantronics audio device on their '
                                      'desktop.',
                       'developer': 'Plantronics, Inc.',
                       'display_name': 'Plantronics Hub',
                       'name': 'PlantronicsHub',
                       'unattended_install': True,
                       'version': '3.21.53118.27704'},
           'repo_subdirectory': 'apps/PlantronicsHub'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/PlantronicsHub/PlantronicsHub-3.21.53118.27704__4.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/PlantronicsHub/PlantronicsHub-3.21.53118.27704.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'PlantronicsHub',
                                                       'pkg_repo_path': 'apps/PlantronicsHub/PlantronicsHub-3.21.53118.27704.pkg',
                                                       'pkginfo_path': 'apps/PlantronicsHub/PlantronicsHub-3.21.53118.27704__4.plist',
                                                       'version': '3.21.53118.27704'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 5, 2, 10, 13, 55),
                                         'munki_version': '5.3.0.4335',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'blocking_applications': ['Plantronics Hub.app'],
                           'catalogs': ['testing'],
                           'description': 'Allows end-users to customize their '
                                          'settings and get visible status of '
                                          'their Plantronics audio device on '
                                          'their desktop.',
                           'developer': 'Plantronics, Inc.',
                           'display_name': 'Plantronics Hub',
                           'installed_size': 221432,
                           'installer_item_hash': '5a70de1e39152790fb7894628d3318f00ce1195486d90a15bb3de8dc292c04cb',
                           'installer_item_location': 'apps/PlantronicsHub/PlantronicsHub-3.21.53118.27704.pkg',
                           'installer_item_size': 78117,
                           'minimum_os_version': '10.5.0',
                           'name': 'PlantronicsHub',
                           'receipts': [{'installed_size': 221432,
                                         'packageid': 'Plantronics-Inc..Plantronics-Hub',
                                         'version': '0'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '3.21.53118.27704'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/PlantronicsHub/PlantronicsHub-3.21.53118.27704.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/PlantronicsHub/PlantronicsHub-3.21.53118.27704__4.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/Applications',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/unpack']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/Applications
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/unpack
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/receipts/PlantronicsHub.munki-receipt-20210502-111355.plist

The following packages were copied:
    Pkg Path                                                                                         
    --------                                                                                         
    /Users/ben/Library/AutoPkg/Cache/com.github.blackthroat.munki.PlantronicsHub/PlantronicsHub.pkg  

The following new items were imported into Munki:
    Name            Version           Catalogs  Pkginfo Path                                                  Pkg Repo Path                                            Icon Repo Path  
    ----            -------           --------  ------------                                                  -------------                                            --------------  
    PlantronicsHub  3.21.53118.27704  testing   apps/PlantronicsHub/PlantronicsHub-3.21.53118.27704__4.plist  apps/PlantronicsHub/PlantronicsHub-3.21.53118.27704.pkg                  
```