### PR TITLE
Add "-universal" to the DMG name

### DIFF
--- a/8bit Solutions LLC/Bitwarden.download.recipe
+++ b/8bit Solutions LLC/Bitwarden.download.recipe
@@ -25,7 +25,7 @@
 				<key>github_repo</key>
 				<string>%GITHUB_REPO%</string>
 				<key>asset_regex</key>
-				<string>%NAME%-[\S]+\.dmg</string>
+				<string>%NAME%-[\S]+-universal\.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
Bitwarden added "-universal" to the DMG names: https://github.com/bitwarden/desktop/commit/6cea5e053d37807ad5e4af781107665639e775cb