### PR TITLE
Update Bitwarden.download.recipe

### DIFF
--- a/8bit Solutions LLC/Bitwarden.download.recipe
+++ b/8bit Solutions LLC/Bitwarden.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>GITHUB_REPO</key>
-		<string>bitwarden/desktop</string>
+		<string>bitwarden/clients</string>
 		<key>NAME</key>
 		<string>Bitwarden</string>
 	</dict>
@@ -25,7 +25,7 @@
 				<key>github_repo</key>
 				<string>%GITHUB_REPO%</string>
 				<key>asset_regex</key>
-				<string>%NAME%-[\S]+\.dmg</string>
+				<string>.*universal\.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
The current Bitwarden releases Github repo is at bitwarden/clients. I also changed the asset_regex, but if it's not the best/most elegant solution, feel free to modify. Thanks!