### PR TITLE
Update Plantronics Hub download URL

### DIFF
--- a/Plantronics, Inc./PlantronicsHub.download.recipe
+++ b/Plantronics, Inc./PlantronicsHub.download.recipe
@@ -23,7 +23,7 @@
                 <key>filename</key>
                 <string>%NAME%.dmg</string>
                 <key>url</key>
-                <string>https://www.poly.com/content/dam/www/software/PlantronicsHubInstaller.dmg</string>
+                <string>https://downloads.poly.com/headsets/PlantronicsHubInstaller.dmg</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Updating the Plantronics Hub URL, as the previous one now redirects to [https://www.hp.com/us-en/poly.html](https://www.hp.com/us-en/poly.html)