### PR TITLE
Fix Pock recipes

### DIFF
--- a/Pock/Pock.download.recipe
+++ b/Pock/Pock.download.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.blackthroat.download.Pock</string>
 	<key>Input</key>
 	<dict>
-		<key>DOWNLOAD_URL</key>
-		<string>https://pock.dev/download.php?file=pock_0_7_2.zip</string>
 		<key>NAME</key>
 		<string>Pock</string>
 	</dict>
@@ -22,10 +20,23 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>re_pattern</key>
+				<string>href="./download\?file=(pock_[\d_]+\.zip)"</string>
+				<key>result_output_var_name</key>
+				<string>zipfile</string>
+				<key>url</key>
+				<string>https://pock.app/</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<string>https://pock.app/builds/%zipfile%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR updates the download method for Pock.

Verbose recipe run output:

```
% autopkg run -vvq 'Pock/Pock.download.recipe'
Processing Pock/Pock.download.recipe...
WARNING: Pock/Pock.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="./download\\?file=(pock_[\\d_]+\\.zip)"',
           'result_output_var_name': 'zipfile',
           'url': 'https://pock.app/'}}
URLTextSearcher: Found matching text (zipfile): pock_0_9_0__22.zip
{'Output': {'zipfile': 'pock_0_9_0__22.zip'}}
URLDownloader
{'Input': {'filename': 'Pock.zip',
           'url': 'https://pock.app/builds/pock_0_9_0__22.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 25 Feb 2022 14:12:49 GMT
URLDownloader: Storing new ETag header: "6218e3e1-36f648"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/downloads/Pock.zip
{'Output': {'download_changed': True,
            'etag': '"6218e3e1-36f648"',
            'last_modified': 'Fri, 25 Feb 2022 14:12:49 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/downloads/Pock.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/downloads/Pock.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/downloads/Pock.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/Pock',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Pock.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/downloads/Pock.zip to ~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/Pock
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/Pock/Pock.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.pigigaldi.pock" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "788D9WZ9Z3")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/Pock/Pock.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/Pock/Pock.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/Pock/Pock.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/Pock/Pock.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 0.9.0 in file ~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/Pock/Pock.app/Contents/Info.plist
{'Output': {'version': '0.9.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/receipts/Pock.download-receipt-20241225-104930.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.blackthroat.download.Pock/downloads/Pock.zip
```