### PR TITLE
Fix ParseHub recipes

### DIFF
--- a/ParseHub/ParseHub.download.recipe
+++ b/ParseHub/ParseHub.download.recipe
@@ -34,6 +34,17 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/ParseHub.app</string>
+				<key>requirement</key>
+				<string>identifier "com.parsehub.client" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = Z7WNN5ZD4C</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/ParseHub/ParseHub.download.recipe
+++ b/ParseHub/ParseHub.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://www.parsehub.com/static/client/parsehub.dmg</string>
+		<string>https://www.parsehub.com/static/client/ParseHub.dmg</string>
 		<key>NAME</key>
 		<string>ParseHub</string>
 	</dict>


### PR DESCRIPTION
This PR adds code signature verification to the ParseHub download recipe, and updates the download URL.

Verbose recipe run output:

```
% autopkg run -vvq 'ParseHub/ParseHub.download.recipe'
Processing ParseHub/ParseHub.download.recipe...
WARNING: ParseHub/ParseHub.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'ParseHub.dmg',
           'url': 'https://www.parsehub.com/static/client/ParseHub.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 04 Nov 2024 16:08:51 GMT
URLDownloader: Storing new ETag header: "6728f193-679ecbc"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.blackthroat.download.ParseHub/downloads/ParseHub.dmg
{'Output': {'download_changed': True,
            'etag': '"6728f193-679ecbc"',
            'last_modified': 'Mon, 04 Nov 2024 16:08:51 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.download.ParseHub/downloads/ParseHub.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.download.ParseHub/downloads/ParseHub.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.download.ParseHub/downloads/ParseHub.dmg/ParseHub.app',
           'requirement': 'identifier "com.parsehub.client" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'Z7WNN5ZD4C'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.download.ParseHub/downloads/ParseHub.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.sD5tND/ParseHub.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.sD5tND/ParseHub.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.sD5tND/ParseHub.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.download.ParseHub/receipts/ParseHub.download-receipt-20241225-104157.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.blackthroat.download.ParseHub/downloads/ParseHub.dmg
```
