### PR TITLE
Deprecate Dashblock recipes

### DIFF
--- a/Datap Inc./Dashblock.download.recipe
+++ b/Datap Inc./Dashblock.download.recipe
@@ -16,9 +16,18 @@
 		<string>Dashblock</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Dashblock's webpage and GitHub repo are offline, so it's likely app development has ended. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Dashblock's webpage and GitHub repo are offline, so it's likely app development has ended. This PR deprecates the Dashblock recipes.