### PR TITLE
Change KNIME.munki parent to grahampugh download

### DIFF
--- a/KNIME GmbH/KNIME_Analytics_Platform.download.recipe
+++ b/KNIME GmbH/KNIME_Analytics_Platform.download.recipe
@@ -16,9 +16,18 @@
 		<string>KNIME_Analytics_Platform</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the KNIME recipes in the grahampugh-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/KNIME GmbH/KNIME_Analytics_Platform.munki.recipe
+++ b/KNIME GmbH/KNIME_Analytics_Platform.munki.recipe
@@ -44,7 +44,7 @@ exit $?</string>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.blackthroat.download.KNIME_Analytics_Platform</string>
+	<string>com.github.grahampugh.download.KNIME</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The KNIME.download recipe in this repo is similar in function to the earlier-created one in grahampugh-recipes. This PR changes your munki recipe to use grahampugh's download recipe as a parent.

This consolidation will help simplify search results and lower maintenance effort. Thank you!

Updated munki recipe verbose output:

```
% autopkg run -vvq 'blackthroat-recipes/KNIME GmbH/KNIME_Analytics_Platform.munki.recipe'
Processing blackthroat-recipes/KNIME GmbH/KNIME_Analytics_Platform.munki.recipe...
WARNING: blackthroat-recipes/KNIME GmbH/KNIME_Analytics_Platform.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'KNIME_Analytics_Platform.dmg',
           'url': 'https://download.knime.org/analytics-platform/macosx/knime-latest-app.macosx.cocoa.x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 30 Sep 2025 20:53:02 GMT
URLDownloader: Storing new ETag header: "2c8ea1d0-6400af02110e6"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.blackthroat.munki.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg
{'Output': {'download_changed': True,
            'etag': '"2c8ea1d0-6400af02110e6"',
            'last_modified': 'Tue, 30 Sep 2025 20:53:02 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.blackthroat.munki.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.munki.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.blackthroat.munki.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg/KNIME*.app',
           'requirement': 'identifier "org.knime.product" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'V7WZJX2HS9'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.blackthroat.munki.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.0J4qOh/KNIME 5.5.2.app' matched from globbed '/private/tmp/dmg.0J4qOh/KNIME*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.0J4qOh/KNIME 5.5.2.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.0J4qOh/KNIME 5.5.2.app: satisfies its Designated Requirement
CodeSignatureVerifier: test-requirement: code failed to satisfy specified code requirement(s)
Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.blackthroat.munki.KNIME_Analytics_Platform/receipts/KNIME_Analytics_Platform.munki-receipt-20251109-124700.plist

The following recipes failed:
    blackthroat-recipes/KNIME GmbH/KNIME_Analytics_Platform.munki.recipe
        Error in com.github.blackthroat.munki.KNIME_Analytics_Platform: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

The following new items were downloaded:
    Download Path                                                                                                                     
    -------------                                                                                                                     
    ~/Library/AutoPkg/Cache/com.github.blackthroat.munki.KNIME_Analytics_Platform/downloads/KNIME_Analytics_Platform.dmg 
```

(The CodeSignatureVerifier error is fixed upstream once [this](https://github.com/autopkg/grahampugh-recipes/pull/180) merges.)