### PR TITLE
Update ClockifyDesktop code signature OU

### DIFF
--- a/COING/ClockifyDesktop.download.recipe
+++ b/COING/ClockifyDesktop.download.recipe
@@ -60,7 +60,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Clockify Desktop.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "coing.ClockifyDesktop" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3PWTDBRQZQ")</string>
+				<string>anchor apple generic and identifier "coing.ClockifyDesktop" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "LA96L67B8C")</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Hi, @blackthroat 

The ClockifyDesktop Recipe is currently failing with the below error
```
The following recipes failed:
    ClockifyDesktop.munki.recipe
        Error in com.github.blackthroat.munki.ClockifyDesktop: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
```

This PR adjusts the CodeSignatureVerifier requirement to expect the new certificate leaf[subject.OU] value (changed from "3PWTDBRQZQ" to "LA96L67B8C"). This updates the signing identity used for code signature verification so the recipe matches the app's current certificate.

Output from a successful -v run 
```
autopkg run -v ClockifyDesktop.munki.recipe
Processing ClockifyDesktop.munki.recipe...
WARNING: ClockifyDesktop.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
SparkleUpdateInfoProvider: Items in feed: 52
SparkleUpdateInfoProvider: Items in default channel: 52
SparkleUpdateInfoProvider: Version retrieved from appcast: 698
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.12.2
SparkleUpdateInfoProvider: Found URL https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop.zip
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.blackthroat.munki.ClockifyDesktop/downloads/ClockifyDesktop-2.12.2.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename ClockifyDesktop-2.12.2.zip
Unarchiver: Unarchived /Users/paul.cossey/Library/AutoPkg/Cache/com.github.blackthroat.munki.ClockifyDesktop/downloads/ClockifyDesktop-2.12.2.zip to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.blackthroat.munki.ClockifyDesktop/ClockifyDesktop
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.blackthroat.munki.ClockifyDesktop/ClockifyDesktop/Clockify Desktop.app: valid on disk
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.blackthroat.munki.ClockifyDesktop/ClockifyDesktop/Clockify Desktop.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.blackthroat.munki.ClockifyDesktop/ClockifyDesktop/Clockify Desktop.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
DmgCreator
DmgCreator: Created dmg from /Users/paul.cossey/Library/AutoPkg/Cache/com.github.blackthroat.munki.ClockifyDesktop/ClockifyDesktop at /Users/paul.cossey/Library/AutoPkg/Cache/com.github.blackthroat.munki.ClockifyDesktop/ClockifyDesktop.dmg
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/ClockifyDesktop/ClockifyDesktop-2.12.2__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/ClockifyDesktop/ClockifyDesktop-2.12.2__1.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.blackthroat.munki.ClockifyDesktop/receipts/ClockifyDesktop.munki-receipt-20260310-101129.plist

The following new items were imported into Munki:
    Name             Version  Catalogs  Pkginfo Path                                          Pkg Repo Path                                       Icon Repo Path  
    ----             -------  --------  ------------                                          -------------                                       --------------  
    ClockifyDesktop  2.12.2   testing   apps/ClockifyDesktop/ClockifyDesktop-2.12.2__1.plist  apps/ClockifyDesktop/ClockifyDesktop-2.12.2__1.dmg 
```